### PR TITLE
Remove time dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.3.0"
 dependencies = [
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14,7 +14,7 @@ name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24,32 +24,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.56"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,10 +63,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+"checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,6 @@ doc = false
 [dependencies]
 getopts = "0.2"
 lazy_static = "1.0"
+
+[dev-dependencies]
 time = "0.1"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ lunisolar calendar. For example the full moon will always be around the middle
 of every month, easy, just look up in the sky to know the time.
 
 A detailed explanation of the date format is available
-[online](https://vinc.cc/essays/geocalendar.html).
+[online](https://vinc.cc/units/geodate).
 
 
 Installation

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate time;
 extern crate getopts;
 extern crate geodate;
 
@@ -9,6 +8,7 @@ use geodate::ephemeris::*;
 use geodate::reverse::*;
 
 use std::env;
+use std::time::SystemTime;
 
 fn encode_float(x: f64) -> String {
     format!("0{}", x)
@@ -84,7 +84,10 @@ fn main() {
     let now = if matches.free.len() == 4 {
         decode_float(&matches.free[3]) as i64
     } else {
-        time::get_time().sec
+        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(time) => time.as_secs() as i64,
+            Err(_) => 0
+        }
     };
 
     if matches.opt_present("e") {

--- a/src/moon_phase.rs
+++ b/src/moon_phase.rs
@@ -1,4 +1,3 @@
-extern crate time;
 
 use std::ops::Rem;
 use math::*;

--- a/src/moon_transit.rs
+++ b/src/moon_transit.rs
@@ -390,11 +390,6 @@ mod tests {
             ("2025-10-21T05:24:26+00:00", "2025-10-21T12:00:00+00:00", -4.0, 0.0),
         ];
         for (t0, t1, lat, lon) in times {
-            println!();
-            println!("{}", t0);
-            let t = get_moonrise(parse_time(t1), lon, lat).unwrap();
-            let d = time::at(time::Timespec::new(t, 0)).to_utc();
-            println!("{} ({}s)", d.strftime("%FT%T+00:00").unwrap(), t - parse_time(t0));
             assert_approx_eq!(get_moonrise(parse_time(t1), lon, lat).unwrap(), parse_time(t0), accuracy);
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-extern crate time;
-
 #[macro_export]
 macro_rules! assert_approx_eq {
     ($a:expr, $b:expr, $e:expr) => ({
@@ -8,7 +6,7 @@ macro_rules! assert_approx_eq {
     })
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn parse_time(iso: &str) -> i64 {
     time::strptime(iso, "%FT%T%z").unwrap().to_timespec().sec
 }


### PR DESCRIPTION
The `time` crate is only needed during tests.