### PR TITLE
Fix negative dates

### DIFF
--- a/src/earth_orbit.rs
+++ b/src/earth_orbit.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn get_previous_december_solstice_test() {
-        let accuracy = 20; // TODO: Improve accuracy
+        let accuracy = 11; // TODO: Improve accuracy
         let solstice_december_2012 = parse_time("2012-12-21T11:11:37.00+00:00");
 
         let times = vec![
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn get_next_december_solstice_test() {
-        let accuracy = 20; // TODO: Improve accuracy
+        let accuracy = 13; // TODO: Improve accuracy
         let solstice_december_2013 = parse_time("2013-12-21T17:11:00.00+00:00");
 
         let times = vec![

--- a/src/geodate.rs
+++ b/src/geodate.rs
@@ -132,9 +132,12 @@ pub fn get_formatted_date(format: &str, timestamp: i64, longitude: f64) -> Strin
     };
 
     y += ((zero - epoch_zero) as f64 / 86400.0 / 365.25).round() as i64;
-    if zero < epoch_zero {
+
+    if y < 0 {
         y = y.abs();
-        res.insert(0, '-');
+        if res.contains("%h") || res.contains("%y") || res.contains("%u") {
+            res.insert(0, '-');
+        }
     }
 
     if res.contains("%h") {


### PR DESCRIPTION
The date zero is 1900-01-01 of the Gregorian calendar because it's more practical than Unix epoch (1970-01-01) for year conversions and had a new moon that day.

Any year before that should have a negative sign, and no sign after the year 0, but that wasn't the case:

```
$ geodate -3.3333 48.5159 $(date -d "1642-01-01 12:00:00" +%s)
-02:58:00:00:62:51

$ geodate -3.3333 48.5159 $(date -d "1900-01-01 12:00:00" +%s)
-00:00:00:00:62:57

$ geodate -3.3333 48.5159 $(date -d "1930-01-01 12:00:00" +%s)
-00:30:00:01:63:23

$ geodate -3.3333 48.5159 $(date -d "1930-01-01 12:00:00" +%s)
00:49:12:13:59:06
```
This is now fixed:

```
$ geodate -3.3333 48.5159 $(date -d "1642-01-01 12:00:00" +%s)
-02:58:00:00:62:51

$ geodate -3.3333 48.5159 $(date -d "1900-01-01 12:00:00" +%s)
00:00:00:00:62:57

$ geodate -3.3333 48.5159 $(date -d "1930-01-01 12:00:00" +%s)
00:30:00:01:63:23

$ geodate -3.3333 48.5159 $(date -d "1930-01-01 12:00:00" +%s)
00:49:12:13:59:06
```